### PR TITLE
fix: allow entire device unique ID to be overwritten

### DIFF
--- a/src/fauxmoESP.cpp
+++ b/src/fauxmoESP.cpp
@@ -454,7 +454,7 @@ unsigned char fauxmoESP::addDevice(const char * device_name) {
     // create the uniqueid
     String mac = WiFi.macAddress();
 
-    snprintf(device.uniqueid, 27, "%s:%s-%02X", mac.c_str(), "00:00", device_id);
+    snprintf(device.uniqueid, FAUXMO_DEVICE_UNIQUE_ID_LENGTH, "%s:%s-%02X", mac.c_str(), "00:00", device_id);
 
     // Attach
     _devices.push_back(device);

--- a/src/fauxmoESP.h
+++ b/src/fauxmoESP.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 #define FAUXMO_TCP_MAX_CLIENTS      10
 #define FAUXMO_TCP_PORT             1901
 #define FAUXMO_RX_TIMEOUT           3
-#define FAUXMO_DEVICE_UNIQUE_ID_LENGTH  12
+#define FAUXMO_DEVICE_UNIQUE_ID_LENGTH  27
 
 //#define DEBUG_FAUXMO                Serial
 #ifdef DEBUG_FAUXMO
@@ -80,7 +80,7 @@ typedef struct {
     char * name;
     bool state;
     unsigned char value;
-    char uniqueid[28];
+    char uniqueid[FAUXMO_DEVICE_UNIQUE_ID_LENGTH];
 } fauxmoesp_device_t;
 
 class fauxmoESP {


### PR DESCRIPTION
https://github.com/vintlabs/fauxmoESP/issues/242